### PR TITLE
Using ClickFunnels API V2

### DIFF
--- a/lib/omniauth/click_funnels.rb
+++ b/lib/omniauth/click_funnels.rb
@@ -20,13 +20,13 @@ module OmniAuth
       }.merge(additional_options)
 
       uid {
-        raw_info.dig("data", "id")
+        raw_info.dig("id")
       }
 
       info do
         {
           # TODO I'm curious how many OAuth providers do this. Seems like most do. Is it part of the protocol?
-          email: raw_info.dig("data", "attributes", "email")
+          email: raw_info.dig("email")
         }.merge(raw_info)
       end
 

--- a/lib/omniauth/click_funnels.rb
+++ b/lib/omniauth/click_funnels.rb
@@ -41,7 +41,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= JSON.parse(access_token.get("/api/v1/me.json").body)
+        @raw_info ||= JSON.parse(access_token.get("/api/v2/me").body)
       end
 
       # https://github.com/intridea/omniauth-oauth2/issues/81

--- a/lib/omniauth/click_funnels/version.rb
+++ b/lib/omniauth/click_funnels/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module ClickFunnels
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/omniauth/click_funnels/version.rb
+++ b/lib/omniauth/click_funnels/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module ClickFunnels
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
I needed the connected_workspace id from the payload, which is in api/v2/me and not in api/v1/me.json.

New extra_info field:

```
{
  "id": 123456,
  "public_id": "ABC123",
  "email": "john.email@example.com",
  "first_name": "John",
  "last_name": "Doe",
  "time_zone": "Pacific Time (US & Canada)",
  "locale": null,
  "created_at": "2023-01-01T00:00:00.000Z",
  "updated_at": "2023-01-02T00:00:00.000Z",
  "connected_workspace": {
    "team_id": 654321,
    "team_name": "Fake Team",
    "workspace_id": 987654,
    "workspace_name": "Fake Workspace",
    "workspace_url": "https://fakeworkspace.example.com"
  },
  "platform_application": {
    "id": 112233,
    "public_id": "XYZ789",
    "team_id": 654321
  }
}
```

Version bumped to 2.0.0 because this is a breaking change.